### PR TITLE
Download directory handling, resumable downloads & creation/modification preservation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ archive are supported.
 Usage of ue4versionator:
   -config string
         ue4versionator config file (default ".ue4versionator")
+  -user-config string
+        ue4versionator user config file (default ".ue4v-user")
+  -virgin
+        ask configuration options like the first time
   -with-engine
         download and unpack UE4 engine build (default true)
   -with-symbols

--- a/archive.go
+++ b/archive.go
@@ -249,6 +249,7 @@ func extract(asset, path, dest string) (err error) {
 		if err = f.Close(); err != nil {
 			return err
 		}
+		os.Chtimes(fpath, hdr.AccessedAt, hdr.ModifiedAt)
 
 		extracted++
 		if time.Since(lastUpdate) > time.Second || extracted == files {

--- a/main.go
+++ b/main.go
@@ -6,21 +6,32 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
 
 	"github.com/go-ini/ini"
 	"golang.org/x/sys/windows/registry"
 )
 
 var (
-	iniConfig    = flag.String("config", ".ue4versionator", "ue4versionator config file")
-	fetchEngine  = flag.Bool("with-engine", true, "download and unpack UE4 engine build")
-	fetchSymbols = flag.Bool("with-symbols", false, "download and unpack UE4 engine debug symbols")
+	iniConfig     = flag.String("config", ".ue4versionator", "ue4versionator config file")
+	userIniConfig = flag.String("user-config", ".ue4v-user", "ue4versionator user config file")
+	fetchEngine   = flag.Bool("with-engine", true, "download and unpack UE4 engine build")
+	fetchSymbols  = flag.Bool("with-symbols", false, "download and unpack UE4 engine debug symbols")
+	virgin        = flag.Bool("virgin", false, "ask configuration options like the first time")
 )
 
 func main() {
 	flag.Parse()
 
 	handleError := func(err error) {
+		if err == nil {
+			return
+		}
+
 		fmt.Println(err)
 		fmt.Print("\nPress 'Enter' to continue...")
 		bufio.NewReader(os.Stdin).ReadBytes('\n')
@@ -28,10 +39,9 @@ func main() {
 	}
 
 	// load ini config
-	cfg, err := ini.Load(*iniConfig)
-	if err != nil {
-		handleError(fmt.Errorf("%s config file not found", *iniConfig))
-	}
+	cfg, err := ini.LooseLoad(*iniConfig, *userIniConfig)
+	handleError(err)
+
 	baseURL, err := cfg.Section("ue4versionator").GetKey("baseurl")
 	if err != nil || baseURL.String() == "" {
 		handleError(fmt.Errorf("%s config file has no baseurl setting", *iniConfig))
@@ -42,13 +52,16 @@ func main() {
 	if len(flag.Args()) > 0 {
 		path = flag.Args()[0]
 	}
+	path, _ = filepath.Abs(path)
 
 	version, err := GetEngineAssociation(path)
 	if err != nil {
 		handleError(fmt.Errorf("error finding engine association with path %s: %v", path, err))
 	}
 
-	dest, err := FetchEngine(baseURL.String(), version, DownloadOptions{
+	downloadDir := getDownloadDirectory(path)
+
+	dest, err := FetchEngine(downloadDir, baseURL.String(), version, DownloadOptions{
 		FetchEngine:  *fetchEngine,
 		FetchSymbols: *fetchSymbols,
 	})
@@ -58,12 +71,94 @@ func main() {
 
 	log.Printf("Registering %s\n", version)
 	key, _, err := registry.CreateKey(registry.CURRENT_USER, `Software\Epic Games\Unreal Engine\Builds`, registry.QUERY_VALUE|registry.SET_VALUE)
-	if err != nil {
-		handleError(err)
-	}
+	handleError(err)
+
 	defer key.Close()
 
-	if err = key.SetStringValue(version, dest); err != nil {
-		handleError(err)
+	err = key.SetStringValue(version, dest)
+	handleError(err)
+}
+
+func getDownloadDirectory(path string) string {
+	cfg, _ := ini.LooseLoad(*userIniConfig)
+	key, err := cfg.Section("ue4v-user").GetKey("download_dir")
+	if err != nil {
+		key, _ = cfg.Section("ue4v-user").NewKey("download_dir", "")
 	}
+
+	if !*virgin && key.String() != "" {
+		return key.String()
+	}
+
+	fmt.Fprintf(os.Stdout, "======================================================================\n")
+	fmt.Fprintf(os.Stdout, "| A custom UE4 engine build needs to be downloaded for this project. |\n")
+	fmt.Fprintf(os.Stdout, "|  These builds can be quite large. Lots of disk space is required.  |\n")
+	fmt.Fprintf(os.Stdout, "======================================================================\n\n")
+	fmt.Fprintf(os.Stdout, "Project path: %v\n\n", path)
+	fmt.Fprintf(os.Stdout, "Which directory should these engine downloads be stored in?\n")
+
+	var options []string
+	const custom = "custom location"
+
+	if user, err := user.Current(); err == nil {
+		options = append(options, filepath.Join(user.HomeDir, ".ue4"))
+	}
+	if abs, err := filepath.Abs(filepath.Join(path, "..", ".ue4")); err == nil {
+		options = append(options, abs)
+	}
+	if runtime.GOOS == "windows" {
+		options = append(options, filepath.Join(filepath.VolumeName(path), "/", ".ue4"))
+	}
+	options = append(options, custom)
+
+	var directory string
+	for {
+		for i, option := range options {
+			fmt.Fprintf(os.Stdout, "\n%d) %s", i+1, option)
+		}
+
+		fmt.Printf("\n\nSelect an option (%d-%d) and press enter: ", 1, len(options))
+
+		input, _ := bufio.NewReader(os.Stdin).ReadByte()
+		parsed, _ := strconv.ParseInt(string(input), 10, 8)
+
+		chosen := int(parsed) - 1
+		if chosen < 0 || int(chosen) >= len(options) {
+			fmt.Printf("Invalid '%s' option. Try again:\n\n", string(input))
+			continue
+		}
+
+		directory = options[chosen]
+		if directory == custom {
+			var err error
+
+			fmt.Printf("\nCustom location: ")
+			directory, _ = bufio.NewReader(os.Stdin).ReadString('\n')
+
+			directory, err = filepath.Abs(strings.TrimSpace(directory))
+			if err != nil {
+				fmt.Println(err)
+				continue
+			}
+			if strings.HasPrefix(directory, path) {
+				fmt.Println("download directory cannot reside in the project directory")
+				continue
+			}
+			if err = os.MkdirAll(directory, 0777); err != nil {
+				fmt.Println(err)
+				continue
+			}
+		}
+
+		if err := os.MkdirAll(directory, 0777); err != nil {
+			fmt.Println(err)
+			continue
+		}
+		break
+	}
+
+	key.SetValue(directory)
+	cfg.SaveTo(*userIniConfig)
+
+	return directory
 }


### PR DESCRIPTION
- User is prompted to specify download location for builds on first run. (#1)
- Downloads can now be resumed. The archive is downloaded to the same disk (rather than TempDir), for faster extraction. The archive is only removed upon successful extraction.
- Creation/modification dates of files should now be preserved.