### PR TITLE
build,ci: add linux build-variant and a small CI to test & publish artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: build ue4versionator
+
+on: [ push, pull_request ]
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: build ue4versionator on Windows
+      shell: bash
+      run: ./build.sh
+
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: build ue4versionator on Linux
+      shell: bash
+      run: ./build.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ jobs:
     - name: build ue4versionator on Windows
       shell: bash
       run: ./build.sh
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ue4versionator.windows
+        path: ue4versionator.exe
 
   linux:
     runs-on: ubuntu-latest
@@ -18,3 +22,7 @@ jobs:
     - name: build ue4versionator on Linux
       shell: bash
       run: ./build.sh
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ue4versionator.linux
+        path: ue4versionator

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,16 @@
-# install mingw-w64 for unarr
-CGO_ENABLED=1 GOARCH=amd64 GOOS=windows CC=x86_64-w64-mingw32-gcc go build -ldflags '-w'
+#!/bin/sh
+
+target="$1"
+
+if [ -z "$target" ] ; then
+	if [ "$(uname)" = "Linux" ] ; then
+		target=linux
+		compiler=gcc
+	else
+		# install mingw-w64 for unarr
+		target=windows
+		compiler=x86_64-w64-mingw32-gcc
+	fi
+fi
+
+CGO_ENABLED=1 GOARCH=amd64 GOOS=${target} CC=${compiler} go build -ldflags '-w'

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -13,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/go-ini/ini"
-	"golang.org/x/sys/windows/registry"
 )
 
 var (
@@ -25,17 +23,17 @@ var (
 	assumeValid   = flag.Bool("assume-valid", false, "assumes current archive is valid, if present")
 )
 
-func main() {
-	flag.Parse()
-
-	handleError := func(err error) {
-		if err == nil {
-			return
-		}
-
-		fmt.Println(err)
-		os.Exit(1)
+func handleError(err error) {
+	if err == nil {
+		return
 	}
+
+	fmt.Println(err)
+	os.Exit(1)
+}
+
+func ue4versionator() (string, string, error) {
+	flag.Parse()
 
 	// load ini config
 	cfg, err := ini.LooseLoad(*iniConfig, *userIniConfig)
@@ -78,18 +76,8 @@ func main() {
 		FetchSymbols: shouldFetchSymbols,
 		AssumeValid: *assumeValid,
 	})
-	if err != nil {
-		handleError(err)
-	}
 
-	log.Printf("Registering %s\n", version)
-	key, _, err := registry.CreateKey(registry.CURRENT_USER, `Software\Epic Games\Unreal Engine\Builds`, registry.QUERY_VALUE|registry.SET_VALUE)
-	handleError(err)
-
-	defer key.Close()
-
-	err = key.SetStringValue(version, dest)
-	handleError(err)
+	return version, dest, err
 }
 
 func getDownloadDirectory(path string) string {

--- a/main_linux.go
+++ b/main_linux.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	ue4versionator()
+}

--- a/main_windows.go
+++ b/main_windows.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"log"
+	"golang.org/x/sys/windows/registry"
+)
+
+func main() {
+	version, dest, err := ue4versionator()
+
+	log.Printf("Registering %s\n", version)
+	key, _, err := registry.CreateKey(registry.CURRENT_USER, `Software\Epic Games\Unreal Engine\Builds`, registry.QUERY_VALUE|registry.SET_VALUE)
+	handleError(err)
+
+	defer key.Close()
+
+	err = key.SetStringValue(version, dest)
+	handleError(err)
+}


### PR DESCRIPTION
This changeset adds support for building ue4versionator on (and for) Linux.
And adds a small CI (via Github Actions) to test the build.

For Windows, the executable should be tested, since this also does some Windows Registry updates.
But on Linux this seemed to work with PBSync (up until another point where PBSync needs more tuning for Linux).

The CI also creates some build-artifacts which last for about 90 days after a build.
Github Actions supports some of these artifacts (for free).
90 days is sufficient to get the artifact and store it somewhere else.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>